### PR TITLE
Implement option for blindspot arcs

### DIFF
--- a/android/app/src/main/java/app/candash/cluster/DashFragment.kt
+++ b/android/app/src/main/java/app/candash/cluster/DashFragment.kt
@@ -1056,7 +1056,7 @@ class DashFragment : Fragment() {
                 }
 
             }
-            if (gearState != Constants.gearPark && gearState != Constants.gearInvalid && gearState != Constants.gearSNA) {
+            if (gearState in setOf(Constants.gearDrive, Constants.gearNeutral, Constants.gearReverse) && !getBooleanPref(Constants.hideBs)) {
                 it.getValue(Constants.leftVehicle)?.let { sensorVal ->
                     if ((sensorVal.toInt() < l1Distance) and (sensorVal.toInt() >= l2Distance)) {
                         binding.blindSpotLeft1a.visibility = View.VISIBLE


### PR DESCRIPTION
based on https://github.com/nmullaney/candash/pull/25

This allows for disabling the sonar blindspot arcs for users who don't find them accurate enough to be useful.

They are enabled by default.

Tested via playing back logged can data from a recording in dense traffic:
- reset app by clearing storage and cache, ensured blindspot arcs were visible by default
- unchecked "Show Blindspot Arcs" in settings, ensured they were no longer visible
- checked "Show Blindspot Arcs" in settings, ensure they were visible again.